### PR TITLE
add: winston logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,10 @@
         "@nestjs/common": "^9.0.0",
         "@nestjs/core": "^9.0.0",
         "@nestjs/platform-express": "^9.0.0",
+        "nest-winston": "^1.9.1",
         "reflect-metadata": "^0.1.13",
-        "rxjs": "^7.2.0"
+        "rxjs": "^7.2.0",
+        "winston": "^3.8.2"
       },
       "devDependencies": {
         "@nestjs/cli": "^9.0.0",
@@ -770,8 +772,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-      "dev": true,
-      "optional": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -796,6 +796,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1995,6 +2005,11 @@
         "@types/superagent": "*"
       }
     },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.2.tgz",
+      "integrity": "sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g=="
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
@@ -2549,6 +2564,11 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
+    "node_modules/async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3085,6 +3105,15 @@
       "integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
       "dev": true
     },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3100,6 +3129,37 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -3415,6 +3475,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -3989,6 +4054,11 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -4116,6 +4186,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/fork-ts-checker-webpack-plugin": {
       "version": "8.0.0",
@@ -4683,7 +4758,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -5480,6 +5554,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -5564,6 +5643,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.5.1.tgz",
+      "integrity": "sha512-9FyqAm9o9NKKfiAKfZoYo9bGXXuwMkxQiQttkT4YjjVtQVIQtK6LmVtlxmCaFswo6N4AfEkHqZTV0taDtPotNg==",
+      "dependencies": {
+        "@colors/colors": "1.5.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
       }
     },
     "node_modules/lru-cache": {
@@ -5781,8 +5873,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multer": {
       "version": "1.4.4-lts.1",
@@ -5832,6 +5923,18 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/nest-winston": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/nest-winston/-/nest-winston-1.9.1.tgz",
+      "integrity": "sha512-L3fjIfas+7ZziKsCQiTYvTVw0Hpv3oN4TDnbLLYLIQgKLNpzQyf/2yZv1/buDPMrGJKrNPwiHLoifjGHon34+A==",
+      "dependencies": {
+        "fast-safe-stringify": "^2.1.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^5.0.0 || ^6.6.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+        "winston": "^3.0.0"
+      }
     },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
@@ -5934,6 +6037,14 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/onetime": {
@@ -6736,6 +6847,14 @@
         }
       ]
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -6949,6 +7068,19 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -6997,6 +7129,14 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -7305,6 +7445,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -7377,6 +7522,11 @@
       "bin": {
         "tree-kill": "cli.js"
       }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "node_modules/ts-jest": {
       "version": "29.0.5",
@@ -7909,6 +8059,66 @@
       "dev": true,
       "engines": {
         "node": ">=8.12.0"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.2.tgz",
+      "integrity": "sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==",
+      "dependencies": {
+        "@colors/colors": "1.5.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.4.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
+      "integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
+      "dependencies": {
+        "logform": "^2.3.2",
+        "readable-stream": "^3.6.0",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 6.4.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
     "@nestjs/common": "^9.0.0",
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
+    "nest-winston": "^1.9.1",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.2.0"
+    "rxjs": "^7.2.0",
+    "winston": "^3.8.2"
   },
   "devDependencies": {
     "@nestjs/cli": "^9.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,10 +1,10 @@
-import { Module } from '@nestjs/common';
+import { Logger, Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 
 @Module({
   imports: [],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, Logger],
 })
 export class AppModule {}

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,8 +1,15 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
+import { objectToLog } from './const/objectToLog';
 
 @Injectable()
 export class AppService {
+  private object = objectToLog;
+  constructor(
+    private readonly logger: Logger, // use nest logger, but is overloaded by winston
+  ) {}
+
   getHello(): string {
+    this.logger.error('Error', this.object);
     return 'Hello World!';
   }
 }

--- a/src/const/objectToLog.ts
+++ b/src/const/objectToLog.ts
@@ -1,0 +1,18 @@
+export const objectToLog = {
+  _id: '644c192a08d0fd5985392f88',
+  index: 0,
+  guid: 'ed5bb200-9ce8-4072-bc7e-366f5e41369f',
+  isActive: true,
+  balance: '$1,538.96',
+  age: 37,
+  eyeColor: 'blue',
+  name: 'Opal Kirby',
+  gender: 'female',
+  company: 'VERAQ',
+  email: 'opalkirby@veraq.com',
+  phone: '+1 (924) 582-3831',
+  address: '884 Cozine Avenue, Ruffin, District Of Columbia, 820',
+  registered: '2019-09-26T08:54:14 +04:00',
+  latitude: -87.363528,
+  longitude: -124.751485,
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,51 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
+import { createLogger } from 'winston';
+
+import {
+  utilities as nestWinstonModuleUtilities,
+  WinstonModule,
+} from 'nest-winston';
+import * as winston from 'winston';
+
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  // create winston logger instance
+  // to replace nest logger
+  const instance = createLogger({
+    format: winston.format.combine(
+      winston.format.timestamp(),
+      winston.format.json(),
+    ),
+
+    transports: [
+      // log redirect to console
+      new winston.transports.Console({
+        format: winston.format.combine(
+          nestWinstonModuleUtilities.format.nestLike('logging-strategy', {
+            colors: true,
+            prettyPrint: true,
+          }),
+        ),
+      }),
+
+      // log redirect to a file
+      new winston.transports.File({
+        filename: 'logfile.log',
+        format: winston.format.json({
+          bigint: true,
+          space: 3,
+        }),
+      }),
+    ],
+  });
+
+  const app = await NestFactory.create(AppModule, {
+    // overload nest logger by the winston logger
+    logger: WinstonModule.createLogger({
+      instance,
+    }),
+  });
   await app.listen(3000);
 }
 bootstrap();


### PR DESCRIPTION
## ❓ Problem

According to notion `Logging Strategy`, we need to implement the  `winston` npm package. To see all the functionnality this libs can provided to our goals.


##  💡 Solution

- Following the github / npm documentation 
- Overload the nest logger by the winston logger (to use globally this logger)
- Trying to log an object in the app service

##  🔨 Testing

- Pull the repo
- Checkout to `poc-with-winston` branch
- run npm i
- run npm  run start:dev
- in postman, reach with GET the route `http://localhost:3000/`, this route generate 2 logs in your console
 
## 📸 Captures

### Winston logger.warn

```javascript
[11:55:13.717] WARN (Opal Kirby/15012):
    req: {
      "id": 1,
      "method": "GET",
      "url": "/",
      "query": {},
      "params": {
        "0": ""
      },
      "headers": {
        "host": "localhost:3000",
        "user-agent": "insomnia/2023.2.0",
        "content-type": "application/json",
        "accept": "*/*",
        "content-length": "0"
      },
      "remoteAddress": "::ffff:127.0.0.1",
      "remotePort": 51874
    }
    context: "AppService"
    _id: "644c192a08d0fd5985392f88"
    index: 0
    guid: "ed5bb200-9ce8-4072-bc7e-366f5e41369f"
    isActive: true
    balance: "$1,538.96"
    age: 37
    eyeColor: "blue"
    gender: "female"
    company: "VERAQ"
    email: "opalkirby@veraq.com"
    phone: "+1 (924) 582-3831"
    address: "884 Cozine Avenue, Ruffin, District Of Columbia, 820"
    registered: "2019-09-26T08:54:14 +04:00"
    latitude: -87.363528
    longitude: -124.751485
```

### Winston logger.error

```javascript
[11:55:13.717] ERROR (Opal Kirby/15012):
    req: {
      "id": 1,
      "method": "GET",
      "url": "/",
      "query": {},
      "params": {
        "0": ""
      },
      "headers": {
        "host": "localhost:3000",
        "user-agent": "insomnia/2023.2.0",
        "content-type": "application/json",
        "accept": "*/*",
        "content-length": "0"
      },
      "remoteAddress": "::ffff:127.0.0.1",
      "remotePort": 51874
    }
    context: "AppService"
    _id: "644c192a08d0fd5985392f88"
    index: 0
    guid: "ed5bb200-9ce8-4072-bc7e-366f5e41369f"
    isActive: true
    balance: "$1,538.96"
    age: 37
    eyeColor: "blue"
    gender: "female"
    company: "VERAQ"
    email: "opalkirby@veraq.com"
    phone: "+1 (924) 582-3831"
    address: "884 Cozine Avenue, Ruffin, District Of Columbia, 820"
    registered: "2019-09-26T08:54:14 +04:00"
    latitude: -87.363528
    longitude: -124.751485
```

### Pino auto added info log after the end of request 

```javascript
[11:55:13.722] INFO (loggin-strategy/15012): request completed
    req: {
      "id": 1,
      "method": "GET",
      "url": "/",
      "query": {},
      "params": {
        "0": ""
      },
      "headers": {
        "host": "localhost:3000",
        "user-agent": "insomnia/2023.2.0",
        "content-type": "application/json",
        "accept": "*/*",
        "content-length": "0"
      },
      "remoteAddress": "::ffff:127.0.0.1",
      "remotePort": 51874
    }
    res: {
      "statusCode": 200,
      "headers": {
        "x-powered-by": "Express",
        "content-type": "text/html; charset=utf-8",
        "content-length": "12",
        "etag": "W/\"c-Lve95gjOVATpfV8EL5X4nxwjKHE\""
      }
    }
    responseTime: 6
```

### Nest logger.warn

```javascript
[Nest] 15355  - 05/01/2023, 11:58:29 AM    WARN [AppService] Object:
{
  "_id": "644c192a08d0fd5985392f88",
  "index": 0,
  "guid": "ed5bb200-9ce8-4072-bc7e-366f5e41369f",
  "isActive": true,
  "balance": "$1,538.96",
  "age": 37,
  "eyeColor": "blue",
  "name": "Opal Kirby",
  "gender": "female",
  "company": "VERAQ",
  "email": "opalkirby@veraq.com",
  "phone": "+1 (924) 582-3831",
  "address": "884 Cozine Avenue, Ruffin, District Of Columbia, 820",
  "registered": "2019-09-26T08:54:14 +04:00",
  "latitude": -87.363528,
  "longitude": -124.751485
}
```

As we can see here, the pino logger by default can add lot of information for each log generated (like header info, remote address, ...). 

We can flag the log type (warn, error), and the timestamp is auto generated by pino.

Otherwise, pino add a `request completed` log with all needed info for the completed request (status code, user agent, route, http verb, ...). 

In comparaison nest cannot add this `log completed` info. 

The nest log is still pertinent but, we cannot have the request info (http verb, user agent, ...) on current request.

