### PR TITLE
add: logLevel logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@nestjs/common": "^9.0.0",
         "@nestjs/core": "^9.0.0",
         "@nestjs/platform-express": "^9.0.0",
+        "loglevel": "^1.8.1",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.2.0"
       },
@@ -5564,6 +5565,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
+      "integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/lru-cache": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@nestjs/common": "^9.0.0",
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
+    "loglevel": "^1.8.1",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.2.0"
   },

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,8 +1,16 @@
 import { Injectable } from '@nestjs/common';
+import { objectToLog } from './const/objectToLog';
+import { getLogger } from 'loglevel';
 
 @Injectable()
 export class AppService {
+  logObject = objectToLog;
+  private readonly logger = getLogger(AppService.name);
+
   getHello(): string {
+    this.logger.warn(this.logObject);
+    this.logger.error(this.logObject);
+
     return 'Hello World!';
   }
 }

--- a/src/const/objectToLog.ts
+++ b/src/const/objectToLog.ts
@@ -1,0 +1,18 @@
+export const objectToLog = {
+  _id: '644c192a08d0fd5985392f88',
+  index: 0,
+  guid: 'ed5bb200-9ce8-4072-bc7e-366f5e41369f',
+  isActive: true,
+  balance: '$1,538.96',
+  age: 37,
+  eyeColor: 'blue',
+  name: 'Opal Kirby',
+  gender: 'female',
+  company: 'VERAQ',
+  email: 'opalkirby@veraq.com',
+  phone: '+1 (924) 582-3831',
+  address: '884 Cozine Avenue, Ruffin, District Of Columbia, 820',
+  registered: '2019-09-26T08:54:14 +04:00',
+  latitude: -87.363528,
+  longitude: -124.751485,
+};


### PR DESCRIPTION
## ❓ Problem

According to notion `Logging Strategy`, we need to implement the  `LogLevel` npm package. To see all the functionnality this libs can provided to our goals.


##  💡 Solution

- Following the github / npm documentation 
- Trying to log an object in the app service

##  🔨 Testing

- Pull the repo
- Checkout to `poc-with-log-level` branch
- run npm i
- run npm run start:dev
- in postman, reach with GET the route `http://localhost:3000/`, this route generate 2 logs in your console
 
## 📸 Captures

### Logger.warn 

``` javascript
{
  _id: '644c192a08d0fd5985392f88',
  index: 0,
  guid: 'ed5bb200-9ce8-4072-bc7e-366f5e41369f',
  isActive: true,
  balance: '$1,538.96',
  age: 37,
  eyeColor: 'blue',
  name: 'Opal Kirby',
  gender: 'female',
  company: 'VERAQ',
  email: 'opalkirby@veraq.com',
  phone: '+1 (924) 582-3831',
  address: '884 Cozine Avenue, Ruffin, District Of Columbia, 820',
  registered: '2019-09-26T08:54:14 +04:00',
  latitude: -87.363528,
  longitude: -124.751485
}
```

### Logger.error 

``` javascript
{
  _id: '644c192a08d0fd5985392f88',
  index: 0,
  guid: 'ed5bb200-9ce8-4072-bc7e-366f5e41369f',
  isActive: true,
  balance: '$1,538.96',
  age: 37,
  eyeColor: 'blue',
  name: 'Opal Kirby',
  gender: 'female',
  company: 'VERAQ',
  email: 'opalkirby@veraq.com',
  phone: '+1 (924) 582-3831',
  address: '884 Cozine Avenue, Ruffin, District Of Columbia, 820',
  registered: '2019-09-26T08:54:14 +04:00',
  latitude: -87.363528,
  longitude: -124.751485
}
```

### Nest logger warn 

```javascript
[Nest] 13608  - 05/01/2023, 11:37:00 AM    WARN [AppService] Object:
{
  "_id": "644c192a08d0fd5985392f88",
  "index": 0,
  "guid": "ed5bb200-9ce8-4072-bc7e-366f5e41369f",
  "isActive": true,
  "balance": "$1,538.96",
  "age": 37,
  "eyeColor": "blue",
  "name": "Opal Kirby",
  "gender": "female",
  "company": "VERAQ",
  "email": "opalkirby@veraq.com",
  "phone": "+1 (924) 582-3831",
  "address": "884 Cozine Avenue, Ruffin, District Of Columbia, 820",
  "registered": "2019-09-26T08:54:14 +04:00",
  "latitude": -87.363528,
  "longitude": -124.751485
}
```

As we can see, LogLevel isn't configurable. we cannot add info (like timestamp, service name, log type). 
Loglevel remove all pertinent information. 
In the nest log, we had all pertinent information (like timestamp, log type, service name).


